### PR TITLE
refactor: update blog fetching logic and improve caching mechanism

### DIFF
--- a/src/app/(blog)/_components/layout/BlogList.tsx
+++ b/src/app/(blog)/_components/layout/BlogList.tsx
@@ -23,7 +23,7 @@ export default function BlogList({
   initialBlogs,
 }: {
   category?: CategoryType;
-  initialBlogs?: BlogType[];
+  initialBlogs: BlogType[];
 }) {
   return (
     <>

--- a/src/app/(blog)/_libs/microCMSFunc.ts
+++ b/src/app/(blog)/_libs/microCMSFunc.ts
@@ -5,23 +5,7 @@ import {
 } from "@/types/BlogType";
 import { BASE_URL } from "./data";
 
-// 最初10件取得(ISR用)
-export async function getInitialBlogs(limit = 10, offset = 0) {
-  const response = await fetch(
-    `${BASE_URL}/api/v1/blog?limit=${limit}&offset=${offset}`,
-    {
-      headers: {
-        "X-MICROCMS-API-KEY": process.env.MICROCMS_API_KEY || "",
-      },
-      method: "GET",
-      // next: { revalidate: 3600 }, // ISR: 1日ごとに再検証
-    }
-  );
-  const data = await response.json();
-  return data.contents as BlogType[];
-}
-
-// 全ブログ取得（Server Action用 - 動的）
+// ブログ取得（Server Action用
 export async function getBlogs(limit = 10, offset = 0) {
   const response = await fetch(
     `${BASE_URL}/api/v1/blog?limit=${limit}&offset=${offset}`,
@@ -30,7 +14,6 @@ export async function getBlogs(limit = 10, offset = 0) {
         "X-MICROCMS-API-KEY": process.env.MICROCMS_API_KEY || "",
       },
       method: "GET",
-      cache: "no-store", // 動的なデータなのでキャッシュしない
     }
   );
   const data = await response.json();
@@ -111,7 +94,7 @@ export async function getSitemapIds() {
   return ids;
 }
 
-// カテゴリ別ブログ取得（Server Action用 - 動的）
+// カテゴリ別ブログ取得
 export async function getBlogsFromCategory(
   category: CategoryType,
   limit = 10,
@@ -152,7 +135,7 @@ export async function getBlogsFromCategory(
   return data.contents as BlogType[];
 }
 
-// 次の記事（より新しい記事）を取得（SSG用）
+// 次の記事（より新しい記事）を取得
 export async function getNextPost(
   currentPublishedAt: string
 ): Promise<PagenationGetBlogType | null> {
@@ -175,7 +158,7 @@ export async function getNextPost(
   }
 }
 
-// 前の記事（より古い記事）を取得（SSG用）
+// 前の記事（より古い記事）を取得
 export async function getPrevPost(
   currentPublishedAt: string
 ): Promise<PagenationGetBlogType | null> {

--- a/src/app/(blog)/category/[slug]/page.tsx
+++ b/src/app/(blog)/category/[slug]/page.tsx
@@ -5,6 +5,7 @@ import BlogList from "@/app/(blog)/_components/layout/BlogList";
 import { Suspense } from "react";
 import BlogListFallback from "../../_components/fallback/BlogListFallback";
 import { notFound } from "next/navigation";
+import { getBlogsFromCategory } from "../../_libs/microCMSFunc";
 
 type CategoryProps = {
   params: Promise<{ slug: "learn" | "important" | "release" | "memory" }>;
@@ -25,6 +26,11 @@ export async function generateMetadata({
       // images: ["/some-specific-page-image.jpg", ...previousImages],
     },
   };
+}
+
+export async function generateStaticParams() {
+  const categories = ["important", "memory", "release", "learn"];
+  return categories.map((category) => ({ slug: category }));
 }
 
 export default async function Category({ params }: CategoryProps) {
@@ -54,12 +60,13 @@ export default async function Category({ params }: CategoryProps) {
     default:
       break;
   }
+  const initialBlogs = await getBlogsFromCategory(category);
   return (
     <div>
       <Intro title="BLOG">カテゴリ：{categoryJapanese}</Intro>
       <Container>
         <Suspense fallback={<BlogListFallback />}>
-          <BlogList category={category} />
+          <BlogList category={category} initialBlogs={initialBlogs} />
         </Suspense>
       </Container>
     </div>

--- a/src/app/(blog)/page.tsx
+++ b/src/app/(blog)/page.tsx
@@ -1,12 +1,12 @@
 import Container from "@/app/(blog)/_components/layout/Container";
 import Intro from "@/app/(blog)/_components/layout/Intro";
 import BlogList from "@/app/(blog)/_components/layout/BlogList";
-import { getInitialBlogs } from "./_libs/microCMSFunc";
+import { getBlogs } from "./_libs/microCMSFunc";
 
 export const revalidate = 3600; // ISR: 1日ごとに再検証
 
 export default async function Home() {
-  const initialBlogs = await getInitialBlogs();
+  const initialBlogs = await getBlogs(10, 0);
   return (
     <div>
       <Intro title="BLOG">何かしらアウトプット用</Intro>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Strengthens initial data flow and adds client-side caching for blog lists.
> 
> - Makes `initialBlogs` a required prop in `BlogList`/`BlogListClient` and prefetches on the server: home uses `getBlogs`, category pages use `getBlogsFromCategory`
> - Implements sessionStorage caching in `BlogListClient` with a timestamped payload and 1-hour TTL, keyed by category; de-duplicates items before persisting
> - Simplifies infinite scroll by removing initial-load guards and relying solely on `IntersectionObserver`
> - Replaces `getInitialBlogs` usage with `getBlogs`, adds `generateStaticParams` for category routes, and removes unnecessary `cache: "no-store"` in fetches
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1f7bcc617145f101116bf6306842c02072e1197. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

fixed #23 